### PR TITLE
Update WIndows build to bash shell

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -93,6 +93,7 @@ jobs:
       
     - name: Debug ARCH_OPTS
       run: echo ARCH_OPTS=${{ env.ARCH_OPTS }}
+      shell: bash
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
@@ -107,10 +108,12 @@ jobs:
         -Wno-dev
         -S ${{ github.workspace }}
         -B ${{ steps.strings.outputs.build-output-dir }}
+      shell: bash
 
     - name: Build
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       run: cmake --build ${{ steps.strings.outputs.build-output-dir }} ${{ env.CONFIG_OPTS }}
+      shell: bash
       
       #--config ${{ matrix.build_type }}
 


### PR DESCRIPTION
For env variable (i.e. `ARCH_OPTS` and `CONFIG_OPTS`) interpolation due to different syntax.

bash shell: `$VAR_NAME`
PowerShell: `$env:VAR_NAME`